### PR TITLE
Update obama_vs_mccain.Rd

### DIFF
--- a/man/obama_vs_mccain.Rd
+++ b/man/obama_vs_mccain.Rd
@@ -19,7 +19,7 @@ and the following columns.
 \item{Non.religious}{Percentage of people identifying as non-religious.}
 \item{Black}{Percentage of people identifying as black.}
 \item{Latino}{Percentage of people identifying as Latino.}
-\item{Urbanization}{Percentage of people living in an urban area.}
+\item{Urbanization}{Population per square mile.}
 }}
 \description{
   State-by-state voting information in the 2008 US


### PR DESCRIPTION
Corrected description of urbanization column in obama_vs_maccain data frame.

The "Urbanization" column is currently descripted as "Percentage of people living in an urban area." which makes no  sense looking at the actual data content. I checked the data source at www.census.gov and discussed the point with Edwin Thoen who provided the data set. We concluded that the "Urbanization" column contains the population per square mile.

@richierocks could you please be so kind and review the change and merge into master if appropriate. 

Thank you & best regards,

Thomas